### PR TITLE
Multiple hostnames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ lib
 lib64
 pyvenv.cfg
 share
-
+*.egg-info

--- a/dab/__main__.py
+++ b/dab/__main__.py
@@ -31,21 +31,26 @@ from dab import Dab
 from dab.dns import DNS
 
 
-parser = argparse.ArgumentParser(description='Get a host fingerprint')
-parser.add_argument('--nameservers', metavar='nameservers', type=lambda x: x.split(','),
-                    help="Comma-separted list of nameservers to use in resolution")
-parser.add_argument('host', metavar='target_host', type=str, nargs='?',
-                    help='a target host')
+def main():
+    parser = argparse.ArgumentParser(description='Get a host fingerprint')
+    parser.add_argument('--nameservers', metavar='nameservers', type=lambda x: x.split(','),
+                        help="Comma-separted list of nameservers to use in resolution")
+    parser.add_argument('host', metavar='target_host', type=str, nargs='?',
+                        help='a target host')
 
-args = parser.parse_args()
-if not args.host:
-    parser.print_help()
-    raise SystemExit()
+    args = parser.parse_args()
+    if not args.host:
+        parser.print_help()
+        raise SystemExit()
 
-loop = asyncio.get_event_loop()
-dab = Dab(args.host, dns_client=DNS(nameservers=args.nameservers or None))
-loop.run_until_complete(dab.fingerprint())
-loop.close()
+    loop = asyncio.get_event_loop()
+    dab = Dab(args.host, dns_client=DNS(nameservers=args.nameservers or None))
+    loop.run_until_complete(dab.fingerprint())
+    loop.close()
 
-for f in sorted(dab.fingerprints):
-    print(f)
+    for f in sorted(dab.fingerprints):
+        print(f)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup, find_packages
+
+__version__ = "0.0.0"
+
+
+setup(
+    name='dab',
+    url="https://github.com/delvelabs/dab",
+    version=__version__,
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'dab = dab.__main__:main'
+        ]
+    },
+    install_requires=[
+        'aiodns>=2.0.0,<3.0',
+        'async_timeout>=3.0.0,<4.0.0',
+    ],
+)


### PR DESCRIPTION
Some DNS servers expose multiple hostnames on a PTR lookup. The name and the aliases are generally interchangeable from call to call, so treating them all as a single list.

While this is not a normal case, it does happen and is supported. Issue documented in the upstream pycares: https://github.com/saghul/pycares/issues/69